### PR TITLE
Option to sync with GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,28 @@ You'll want to use the following [Sync Gateway Config](https://github.com/couchb
 
 ## Syncing with Google Cloud Messaging
 
-* Build Sync Gateway from master and start it with the sync-gateway-config.json
-* Download the notification worker binary from [here](http://cl.ly/1c103T1b0R2B) and start it from the command line
-* Start the application and switch the GCM toggle, now the emulators/devices should sync with GCM and you should
-see a toast message when a notification to sync was received
+* Build Sync Gateway from [master](https://github.com/couchbase/sync_gateway) and start it with the sync-gateway-config.json file
+* Start the application and make sure it connects to the Sync Gateway.
+* Open the drawer panel and toggle the switcher to GCM. Then, check in the admin UI (`http://localhost:4985/_admin/db/todos`)
+that the device token was saved and synced on the profile document:
+```
+{
+  "device_tokens": [
+    "APA91bHE6LfnaKK9DDe9aHLnfim6IfkLLkqvWvFMLsF8BKhv6nEhaNwNo_e9dvdYoWQ2LDFszWhI-B4Dmvvwl8GCbqQ-fpAB-hqGtcheLk48BqnmWJsmQ-1ELlb9v1Hwx4ZzGnzCM7ydNf9ayEinKHnfOXPmG4_Zxw"
+  ],
+  "name": "James Nocentini",
+  "type": "profile",
+  "user_id": "1406037206384636",
+  "_rev": "2-26d69939231b1e6a07bc3af44fb334dc",
+  "_id": "profile:1406037206384636"
+}
+```
+* Download the notification worker binary from [here](https://github.com/jamiltz/ToDoLite-Notifications/releases/latest) and start it from the command line
+* Now the emulators/devices should sync with GCM and you should see a toast message when a notification is received
 
-![img](http://f.cl.ly/items/3E270p0K1o3e3C1Z0m0W/Screen%20Shot%202015-04-20%20at%2022.12.58.png)
+**Note:** the source for the notification worker is in the [ToDoLite-Notifications](https://github.com/jamiltz/ToDoLite-Notifications) repo.
+
+![img](http://f.cl.ly/items/1m1e3T3w160X3Z0l3E34/screenshots.png)
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ If you're running the app on a `Genymotion` emulator, the IP address would be `1
 
 You'll want to use the following [Sync Gateway Config](https://github.com/couchbaselabs/ToDoLite-iOS/blob/master/sync-gateway-config.json)
 
+## Syncing with Google Cloud Messaging
+
+* Build Sync Gateway from master and start it with the sync-gateway-config.json
+* Download the notification worker binary from [here](http://cl.ly/1c103T1b0R2B) and start it from the command line
+* Start the application and switch the GCM toggle, now the emulators/devices should sync with GCM and you should
+see a toast message when a notification to sync was received
+
+![img](http://f.cl.ly/items/3E270p0K1o3e3C1Z0m0W/Screen%20Shot%202015-04-20%20at%2022.12.58.png)
+
 ## Community
 
 If you have any comments or suggestions, please join [our mailing list](https://groups.google.com/forum/#!forum/mobile-couchbase) and let us know.

--- a/ToDoLite/build.gradle
+++ b/ToDoLite/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:21.+'
     compile 'de.hdodenhof:circleimageview:1.2.1'
     compile 'com.android.support:recyclerview-v7:21.0.+'
+    compile "com.google.android.gms:play-services:3.1.+"
 
     compile project(':libraries:couchbase-lite-android')
     compile project(':libraries:couchbase-lite-java-core')

--- a/ToDoLite/src/main/AndroidManifest.xml
+++ b/ToDoLite/src/main/AndroidManifest.xml
@@ -5,6 +5,13 @@
     <uses-feature android:name="android.hardware.camera" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+
+    <permission android:name="com.couchbase.todolite.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
+    <uses-permission android:name="com.couchbase.todolite.permission.C2D_MESSAGE" />
 
     <application
         android:name="com.couchbase.todolite.Application"
@@ -37,6 +44,16 @@
         <activity
             android:name=".ListConflicts">
         </activity>
+
+        <receiver
+            android:name=".GcmBroadcastReceiver"
+            android:permission="com.google.android.c2dm.permission.SEND" >
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+                <category android:name="com.couchbase.todolite" />
+            </intent-filter>
+        </receiver>
+        <service android:name=".GcmMessageHandler" />
     </application>
 
 </manifest>

--- a/ToDoLite/src/main/java/com/couchbase/todolite/Application.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/Application.java
@@ -114,7 +114,7 @@ public class Application extends android.app.Application {
 
     public void startReplicationSyncWithCustomCookie(String cookieValue) {
 
-        sync = new Synchronize.Builder(getDatabase(), SYNC_URL)
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, true)
                 .cookieAuth(cookieValue)
                 .addChangeListener(getReplicationChangeListener())
                 .build();
@@ -124,7 +124,7 @@ public class Application extends android.app.Application {
 
     public void startReplicationSyncWithStoredCustomCookie() {
 
-        sync = new Synchronize.Builder(getDatabase(), SYNC_URL)
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, true)
                 .addChangeListener(getReplicationChangeListener())
                 .build();
         sync.start();
@@ -133,7 +133,7 @@ public class Application extends android.app.Application {
 
     public void startReplicationSyncWithStoredBasicAuth() {
 
-        sync = new Synchronize.Builder(getDatabase(), SYNC_URL)
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, true)
                 .basicAuth(getCurrentUserId(), getCurrentUserPassword())
                 .addChangeListener(getReplicationChangeListener())
                 .build();
@@ -144,7 +144,7 @@ public class Application extends android.app.Application {
 
     public void startReplicationSyncWithBasicAuth(String username, String password) {
 
-        sync = new Synchronize.Builder(getDatabase(), SYNC_URL)
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, true)
                 .basicAuth(username, password)
                 .addChangeListener(getReplicationChangeListener())
                 .build();
@@ -154,12 +154,37 @@ public class Application extends android.app.Application {
 
     public void startReplicationSyncWithFacebookLogin(String accessToken) {
 
-        sync = new Synchronize.Builder(getDatabase(), SYNC_URL)
+        if (sync != null) {
+            sync.destroyReplications();
+        }
+
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, true)
                 .facebookAuth(accessToken)
                 .addChangeListener(getReplicationChangeListener())
                 .build();
         sync.start();
 
+    }
+
+    public void startContinuousPushAndOneShotPull(String accessToken) {
+
+        if (sync != null) {
+            sync.destroyReplications();
+        }
+
+        sync = new Synchronize.Builder(getDatabase(), SYNC_URL, false)
+                .facebookAuth(accessToken)
+                .addChangeListener(getReplicationChangeListener())
+                .build();
+
+
+       sync.start();
+
+    }
+
+    public void stopSync() {
+        sync.destroyReplications();
+        sync = null;
     }
 
     public void migrateGuestDataToUser(Document profile) {

--- a/ToDoLite/src/main/java/com/couchbase/todolite/GcmBroadcastReceiver.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/GcmBroadcastReceiver.java
@@ -1,0 +1,22 @@
+package com.couchbase.todolite;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+
+public class GcmBroadcastReceiver extends WakefulBroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // Explicitly specify that GcmMessageHandler will handle the intent.
+        ComponentName component = new ComponentName(context.getPackageName(),
+                GcmMessageHandler.class.getName());
+
+        // Start the service, keeping the device awake while it is launching.
+        startWakefulService(context, (intent.setComponent(component)));
+        setResultCode(Activity.RESULT_OK);
+    }
+
+}

--- a/ToDoLite/src/main/java/com/couchbase/todolite/GcmMessageHandler.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/GcmMessageHandler.java
@@ -1,0 +1,65 @@
+package com.couchbase.todolite;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.os.Handler;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.couchbase.lite.replicator.Replication;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class GcmMessageHandler extends IntentService {
+
+    private Handler handler;
+    public GcmMessageHandler() {
+        super("GcmMessageHandler");
+    }
+    private Intent mIntent;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        handler = new Handler();
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        mIntent = intent;
+        showToast();
+        Application application = (Application) getApplication();
+
+        try {
+            URL url = new URL(BuildConfig.SYNC_URL_HTTP);
+            Replication pull = application.getDatabase().createPullReplication(url);
+            pull.addChangeListener(getReplicationListener());
+            pull.start();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private Replication.ChangeListener getReplicationListener() {
+        return new Replication.ChangeListener() {
+            @Override
+            public void changed(Replication.ChangeEvent event) {
+                Log.i("GCM", "replication status is : " + event.getSource().getStatus());
+                if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_STOPPED) {
+                    GcmBroadcastReceiver.completeWakefulIntent(mIntent);
+                }
+            }
+        };
+    }
+
+    public void showToast(){
+        handler.post(new Runnable() {
+            public void run() {
+                Toast.makeText(getApplicationContext(), "Server ping - sync down!", Toast.LENGTH_LONG).show();
+            }
+        });
+
+    }
+}

--- a/ToDoLite/src/main/java/com/couchbase/todolite/Synchronize.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/Synchronize.java
@@ -33,7 +33,7 @@ public class Synchronize {
         private boolean basicAuth;
         private boolean cookieAuth;
 
-        public Builder(Database database, String url) {
+        public Builder(Database database, String url, Boolean continuousPull) {
 
             if (pullReplication == null && pushReplication == null) {
 
@@ -45,7 +45,8 @@ public class Synchronize {
                 }
 
                 pullReplication = database.createPullReplication(syncUrl);
-                pullReplication.setContinuous(true);
+                if (continuousPull == true)
+                    pullReplication.setContinuous(true);
 
                 pushReplication = database.createPushReplication(syncUrl);
                 pushReplication.setContinuous(true);

--- a/ToDoLite/src/main/res/layout/activity_main.xml
+++ b/ToDoLite/src/main/res/layout/activity_main.xml
@@ -1,13 +1,11 @@
-<LinearLayout
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:orientation="vertical">
 
     <!-- A DrawerLayout is intended to be used as the top-level content view using match_parent for both width and height to consume the full space available. -->
-    <android.support.v4.widget.DrawerLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+    <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         android:id="@+id/drawer_layout"
         android:layout_width="match_parent"
@@ -15,13 +13,13 @@
         tools:context="com.couchbase.todolite.MainActivity">
 
         <LinearLayout
-            android:layout_height="match_parent"
             android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:orientation="vertical">
 
             <include
-                layout="@layout/tool_bar"
-                android:id="@+id/toolbar"/>
+                android:id="@+id/toolbar"
+                layout="@layout/tool_bar" />
 
             <!-- As the main content view, the view below consumes the entire
              space available using match_parent in both dimensions. -->
@@ -36,26 +34,27 @@
              this as a sliding drawer on the left side for left-to-right
              languages and on the right side for right-to-left languages.
              If you're not building against API 17 or higher, use
-             android:layout_gravity="left" instead. -->
+             android:layout_gravity="left" instead  . -->
         <!-- The drawer is given a fixed width in dp and extends the full height of
              the container. -->
 
         <LinearLayout
             android:id="@+id/drawer"
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:layout_gravity="start"
             android:orientation="vertical">
 
             <include layout="@layout/profile_view" />
+
+            <include layout="@layout/settings_view" />
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/recycler_view"
                 android:layout_width="@dimen/navigation_drawer_width"
                 android:layout_height="match_parent"
                 android:background="#ffffff"
-                android:scrollbars="vertical">
-            </android.support.v7.widget.RecyclerView>
+                android:scrollbars="vertical"></android.support.v7.widget.RecyclerView>
 
         </LinearLayout>
 

--- a/ToDoLite/src/main/res/layout/settings_view.xml
+++ b/ToDoLite/src/main/res/layout/settings_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="@dimen/navigation_drawer_width"
+    android:layout_height="wrap_content"
+    android:padding="12dp"
+    android:columnCount="3"
+    android:background="#ffffff"
+    tools:ignore="UselessParent">
+
+    <!-- Sync Gateway -->
+
+    <TextView
+        android:layout_columnSpan="3"
+        android:layout_width="0dp"
+        android:layout_gravity="start|fill_horizontal"
+        android:text="Sync Gateway"/>
+
+    <TextView
+        android:layout_gravity="start|center_vertical"
+        android:text="Continuous"/>
+
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/toggleGCM"
+        android:layout_gravity="start|center_vertical"
+        android:onClick="onSyncMethodToggleClicked"/>
+
+    <TextView
+        android:layout_gravity="start|center_vertical"
+        android:text="GCM"/>
+
+</GridLayout>


### PR DESCRIPTION
Changes are only to handle the push notification and trigger the pull replication.
I think it's useful to show people how to switch between continuous and GCM.
Currently the changes feed worker is a binary downloadable (see readme changes to get it to work).
The source code for it could go in another repo. I haven't done that yet.
That way, TodoLite iOS and Android would reference the same binary from that repo.