### PR TITLE
Use a ModelHelper to save a List doc

### DIFF
--- a/ToDoLite/src/main/java/com/couchbase/todolite/MainActivity.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/MainActivity.java
@@ -35,6 +35,7 @@ import com.couchbase.lite.LiveQuery;
 import com.couchbase.lite.QueryEnumerator;
 import com.couchbase.lite.replicator.Replication;
 import com.couchbase.lite.util.Log;
+import com.couchbase.todolite.helper.ModelHelper;
 import com.couchbase.todolite.document.List;
 import com.couchbase.todolite.document.Profile;
 import com.facebook.Session;
@@ -42,7 +43,10 @@ import com.google.android.gms.gcm.GoogleCloudMessaging;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Observable;
@@ -397,14 +401,24 @@ public class MainActivity extends BaseActivity {
                     // TODO: Show an error message.
                     return;
                 }
-                try {
-                    String currentUserId = ((Application)getApplication()).getCurrentUserId();
-                    Document document = List.createNewList(getDatabase(), title, currentUserId);
-                    displayListContent(document.getId());
-                    invalidateOptionsMenu();
-                } catch (CouchbaseLiteException e) {
-                    Log.e(Application.TAG, "Cannot create a new list", e);
-                }
+                String currentUserId = ((Application)getApplication()).getCurrentUserId();
+
+                SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+                Calendar calendar = GregorianCalendar.getInstance();
+                String currentTimeString = dateFormatter.format(calendar.getTime());
+
+                List list = new List();
+                list.setType("list");
+                list.setTitle(title);
+                list.setCreateAt(currentTimeString);
+                list.setMembers(new ArrayList<String>());
+
+                if (currentUserId != null)
+                    list.setOwner("profile" + currentUserId);
+
+                Document document = ModelHelper.save(getDatabase(), list);
+                displayListContent(document.getId());
+                invalidateOptionsMenu();
             }
         });
 

--- a/ToDoLite/src/main/java/com/couchbase/todolite/document/List.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/document/List.java
@@ -16,6 +16,8 @@ import com.couchbase.lite.Revision;
 import com.couchbase.lite.UnsavedRevision;
 import com.couchbase.lite.util.Log;
 import com.couchbase.todolite.Application;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -24,9 +26,27 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class List {
     private static final String VIEW_NAME = "lists";
     private static final String DOC_TYPE = "list";
+
+    @JsonProperty(value = "_id")
+    private String documentId;
+
+    private String title;
+
+    @JsonProperty(value = "user_id")
+    private int userId;
+
+    @JsonProperty(value = "created_at")
+    private String createAt;
+
+    private String type;
+
+    private ArrayList<String> members;
+
+    private String owner;
 
     public static Query getQuery(Database database) {
         com.couchbase.lite.View view = database.getView(VIEW_NAME);
@@ -44,26 +64,6 @@ public class List {
 
         Query query = view.createQuery();
         return query;
-    }
-
-    public static Document createNewList(Database database, String title, String userId)
-            throws CouchbaseLiteException {
-        SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        Calendar calendar = GregorianCalendar.getInstance();
-        String currentTimeString = dateFormatter.format(calendar.getTime());
-
-        Map<String, Object> properties = new HashMap<String, Object>();
-        properties.put("type", "list");
-        properties.put("title", title);
-        properties.put("created_at", currentTimeString);
-        properties.put("members", new ArrayList<String>());
-        if (userId != null)
-            properties.put("owner", "profile:" + userId);
-
-        Document document = database.createDocument();
-        document.putProperties(properties);
-
-        return document;
     }
 
     public static void assignOwnerToListsIfNeeded(Database database, Document user)
@@ -113,5 +113,45 @@ public class List {
         newProperties.put("members", members);
 
         list.putProperties(newProperties);
+    }
+
+    public String getCreateAt() {
+        return createAt;
+    }
+
+    public void setCreateAt(String createAt) {
+        this.createAt = createAt;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public ArrayList<String> getMembers() {
+        return members;
+    }
+
+    public void setMembers(ArrayList<String> members) {
+        this.members = members;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
     }
 }

--- a/ToDoLite/src/main/java/com/couchbase/todolite/helper/ModelHelper.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/helper/ModelHelper.java
@@ -1,0 +1,42 @@
+package com.couchbase.todolite.helper;
+
+import com.couchbase.lite.CouchbaseLiteException;
+import com.couchbase.lite.Database;
+import com.couchbase.lite.Document;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class ModelHelper {
+
+    public static Document save(Database database, Object object) {
+        ObjectMapper m = new ObjectMapper();
+        Map<String, Object> props = m.convertValue(object, Map.class);
+        String id = (String) props.get("_id");
+
+        Document document;
+        if (id == null) {
+            document = database.createDocument();
+        } else {
+            document = database.getExistingDocument(id);
+            if (document == null) {
+                document = database.getDocument(id);
+            } else {
+                props.put("_rev", document.getProperty("_rev"));
+            }
+        }
+
+        try {
+            document.putProperties(props);
+        } catch (CouchbaseLiteException e) {
+            e.printStackTrace();
+        }
+        return document;
+    }
+
+    public static <T> T modelForDocument(Document document, Class<T> aClass) {
+        ObjectMapper m = new ObjectMapper();
+        return m.convertValue(document.getProperties(), aClass);
+    }
+
+}


### PR DESCRIPTION
Same method in ToDoLite-iOS is [here](https://github.com/couchbaselabs/ToDoLite-iOS/blob/master/ToDoLite/MasterViewController.m#L199-L216).

In this PR, ModelHelper is a simple class to serialize/deserialize json docs to model classes.

I'm not sure if this ModelHelper should also handle the 1::1 relationship between the model and the document.

CBLModel subclasses have a `document` property to keep a reference to a document from the model.

Would be good to have that too but without the subclassing mechanism as this is just a model helper (not a full featured ODM).