### PR TITLE
change profile document prefix id

### DIFF
--- a/ToDoLite/src/main/java/com/couchbase/todolite/document/Profile.java
+++ b/ToDoLite/src/main/java/com/couchbase/todolite/document/Profile.java
@@ -90,7 +90,7 @@ public class Profile {
         properties.put("user_id", userId);
         properties.put("name", name);
 
-        Document document = database.getDocument("profile:" + userId);
+        Document document = database.getDocument("p:" + userId);
         document.putProperties(properties);
 
         return document;


### PR DESCRIPTION
TodoLite iOS uses a single letter prefix (see [here](https://github.com/couchbaselabs/ToDoLite-iOS/blob/master/ToDoLite/Profile.m#L33)).
Change the prefix to `p:` on TodoLite Android.